### PR TITLE
aligning working (check micro.png)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ make.bat
 .python-version
 pyproject.toml
 uv.lock
+.vscode
+*.ipynb
+test.sh
 
 assets/sample_data/demo/overlay.tif

--- a/controller.py
+++ b/controller.py
@@ -19,8 +19,17 @@ class Controller:
         self.reference_view = core.canvas.ReferenceGraphicsView()
         self.view = app
 
-        self.model_canvas.update_manager.connect(self.view.add_item_to_manager)
-        self.reference_view.update_manager.connect(self.view.add_item_to_manager)
+
+        # Alignment Section signals
+        self.view.images_tab.tissue_target_selected.connect(self.view.cell_layer_alignment.set_target_image)
+        self.view.images_tab.tissue_unaligned_selected.connect(self.view.cell_layer_alignment.set_unaligned_image)
+        self.view.cell_layer_alignment.alignmentCompleteSignal.connect(self.view.images_tab.add_item)
+        self.view.cell_layer_alignment.replaceLayerSignal.connect(self.view.replace_layer_in_canvas)
+        self.view.cell_layer_alignment.loadOnCanvasSignal.connect(self.view.canvas.addNewImage)
+        self.view.cell_layer_alignment.aligner.progress.connect(self.view.update_progress_bar)
+
+        self.model_canvas.update_manager.connect(self.view.images_tab.add_item)
+        self.reference_view.update_manager.connect(self.view.images_tab.add_item)
 
         self.openFilesDialog = None
         #menubar signals

--- a/core/canvas.py
+++ b/core/canvas.py
@@ -165,6 +165,7 @@ class __BaseGraphicsView(QWidget):
             self.lut_cache.clear()
             self.updateProgress.emit(100, "Image Loaded")
 
+            print("MING",channel_one_image.dtype)
             self.update_manager.emit(channel_one_image, "Image"  + " " + str(self.image_count))
             self.image_count+=1
 

--- a/core/cell_layer_alignment.py
+++ b/core/cell_layer_alignment.py
@@ -1,25 +1,44 @@
-import numpy as np
 import cv2
+import numpy as np
 from PyQt6.QtCore import pyqtSignal, QThread, QObject
-
+from pystackreg import StackReg
+from skimage import transform
+from utils import build_optical_flow_pyramid_pure_numpy, adjust_contrast
 class CellLayerAligner(QThread):
     """Worker thread for aligning cell layers"""
     progress = pyqtSignal(int, str)
     error = pyqtSignal(str)
     aligned_image_signal = pyqtSignal(np.ndarray, np.ndarray, np.ndarray)  # Full aligned image, downscaled target, downscaled aligned
     
-    def __init__(self, target_image=None, unaligned_image=None):
+    def __init__(self, pyramid_level=3):
         super().__init__()
-        self.target_image = target_image
-        self.unaligned_image = unaligned_image
+        self.target_image = np.zeros(0)
+        self.unaligned_image = np.zeros(0)
         self.result = None
-        self.downscale_factor = 4  # For initial alignment
-        
-    def set_images(self, target_image, unaligned_image):
-        """Set the target and unaligned images for processing"""
+        self.pyramid_level = pyramid_level # For initial alignment
+        self.downscale_level = -1 # Use most course level for now
+        self.target_pyramid = []
+        self.unaligned_pyramid =[]     
+    
+    def set_target_image(self,target_image):
         self.target_image = target_image
-        self.unaligned_image = unaligned_image
+        # Ensure both images are uint8
+        self.progress.emit(20, "Converting images")
+        target_gray_8bit = self.to_uint8(self.target_image)
+        # Downscale images for faster processing
+        self.progress.emit(50, "Downscaling images")
+        self.target_pyramid = build_optical_flow_pyramid_pure_numpy(target_gray_8bit,self.pyramid_level)
+        self.progress.emit(100, "Done Setting Target Image")
+    
+    def set_unaligned_image(self,unaligned_image):
         
+        self.unaligned_image = unaligned_image
+        self.progress.emit(20, "Converting images")
+        unaligned_gray_8bit = self.to_uint8(self.unaligned_image)
+        self.progress.emit(50, "Downscaling images")
+        self.unaligned_pyramid = build_optical_flow_pyramid_pure_numpy(unaligned_gray_8bit,self.pyramid_level)
+        self.progress.emit(100, "Done Setting Unaligned Image")
+    
     def run(self):
         """Main processing function that runs in the thread"""
         if self.target_image is None or self.unaligned_image is None:
@@ -27,50 +46,28 @@ class CellLayerAligner(QThread):
             return
             
         try:
-            self.progress.emit(10, "Preparing images for alignment")
-            
-            # Convert images to grayscale if they're not already
-            if len(self.target_image.shape) > 2 and self.target_image.shape[2] > 1:
-                target_gray = cv2.cvtColor(self.target_image, cv2.COLOR_BGR2GRAY)
-            else:
-                target_gray = self.target_image
-                
-            if len(self.unaligned_image.shape) > 2 and self.unaligned_image.shape[2] > 1:
-                unaligned_gray = cv2.cvtColor(self.unaligned_image, cv2.COLOR_BGR2GRAY)
-            else:
-                unaligned_gray = self.unaligned_image
-            
-            # Ensure both images are uint8
-            self.progress.emit(20, "Converting images")
-            target_gray_8bit = self.to_uint8(target_gray)
-            unaligned_gray_8bit = self.to_uint8(unaligned_gray)
-            
-            # Downscale images for faster processing
-            self.progress.emit(25, "Downscaling images")
-            target_small = target_gray_8bit[::self.downscale_factor, ::self.downscale_factor]
-            unaligned_small = unaligned_gray_8bit[::self.downscale_factor, ::self.downscale_factor]
-            
+            target_small = self.target_pyramid[self.downscale_level] 
+            unaligned_small = self.unaligned_pyramid[self.downscale_level]
+            target_small = target_small[:min(target_small.shape[0], unaligned_small.shape[0]), :min(target_small.shape[1], unaligned_small.shape[1])]
+            unaligned_small = unaligned_small[:min(target_small.shape[0], unaligned_small.shape[0]), :min(target_small.shape[1], unaligned_small.shape[1])]
             # Enhance contrast using histogram equalization
             self.progress.emit(30, "Enhancing contrast")
-            target_small = self.adjust_contrast(target_small)
-            unaligned_small = self.adjust_contrast(unaligned_small)
+            target_small = adjust_contrast(target_small,50,99)
+            unaligned_small = adjust_contrast(unaligned_small,50,99)
             
             # Perform SIFT-based alignment on small images
             self.progress.emit(40, "Detecting features")
-            H = self.align_images_sift(unaligned_small, target_small)
-            
+            aligned_small,H = self.align_images(unaligned_small, target_small)
             if H is None:
                 self.error.emit("Could not find a valid transformation - not enough matches")
                 return
             
             # Apply homography to full-size image
             self.progress.emit(80, "Applying transformation to full image")
-            height, width = target_gray.shape
-            aligned_image = cv2.warpPerspective(self.unaligned_image, H, (width, height))
-                
-            self.result = aligned_image
+            aligned_image = self.warp_image(self.unaligned_image,H)
+            self.result = self.to_uint8(aligned_image)
             self.progress.emit(100, "Alignment complete")
-            self.aligned_image_signal.emit(aligned_image, target_small, unaligned_small)
+            self.aligned_image_signal.emit(self.result, target_small, aligned_small)
             
         except Exception as e:
             self.error.emit(f"Error during alignment: {str(e)}")
@@ -89,101 +86,18 @@ class CellLayerAligner(QThread):
         else:
             return np.zeros_like(image, dtype=np.uint8)
     
-    def adjust_contrast(self, img, min_percentile=2, max_percentile=98):
-        """Adjust image contrast using percentile-based clipping"""
-        # Calculate percentiles
-        minval = np.percentile(img, min_percentile)
-        maxval = np.percentile(img, max_percentile)
+    def align_images(self, unaligned, target):
+        sr = StackReg(StackReg.AFFINE)
+        out_tra = sr.register_transform(target, unaligned)
+        mat = sr.get_matrix()
+        scale = unaligned.shape[0]/self.unaligned_image.shape[0]
+        S = np.diag([scale,scale,1.0])
+        S_inv = np.linalg.inv(S)
+        H_full = S_inv @ mat @ S
+        return out_tra, H_full
         
-        # Clip and rescale
-        img_adjusted = np.clip(img, minval, maxval)
-        img_adjusted = ((img_adjusted - minval) / (maxval - minval)) * 255
-        return img_adjusted.astype(np.uint8)
-    
-    def align_images_sift(self, floating_img, target_img):
-        """Align images using SIFT feature detection and FLANN-based matching"""
-        try:
-            # Try to create SIFT detector
-            sift = cv2.SIFT_create()
-            
-            # Detect keypoints and compute descriptors
-            kp1, des1 = sift.detectAndCompute(floating_img, None)
-            kp2, des2 = sift.detectAndCompute(target_img, None)
-            
-            using_sift = True
-        except cv2.error:
-            # Fall back to ORB if SIFT is not available
-            self.progress.emit(45, "SIFT unavailable, using ORB")
-            orb = cv2.ORB_create(nfeatures=2000)
-            
-            # Detect keypoints and compute descriptors with ORB
-            kp1, des1 = orb.detectAndCompute(floating_img, None)
-            kp2, des2 = orb.detectAndCompute(target_img, None)
-            
-            using_sift = False
-        
-        # Check if descriptors were found
-        if des1 is None or des2 is None or len(des1) < 2 or len(des2) < 2:
-            return None
-        
-        if using_sift:
-            # Set up FLANN-based matcher for SIFT
-            FLANN_INDEX_KDTREE = 1
-            index_params = dict(algorithm=FLANN_INDEX_KDTREE, trees=5)
-            search_params = dict(checks=50)
-            
-            try:
-                flann = cv2.FlannBasedMatcher(index_params, search_params)
-                matches = flann.knnMatch(des1, des2, k=2)
-                
-                # Apply ratio test to get good matches
-                self.progress.emit(50, "Filtering matches")
-                good_matches = []
-                for m, n in matches:
-                    if m.distance < 0.7 * n.distance:
-                        good_matches.append(m)
-            except Exception:
-                # Fall back to brute force matcher if FLANN fails
-                self.progress.emit(50, "Using brute force matcher")
-                bf = cv2.BFMatcher()
-                matches = bf.knnMatch(des1, des2, k=2)
-                
-                # Apply ratio test
-                good_matches = []
-                for m, n in matches:
-                    if m.distance < 0.7 * n.distance:
-                        good_matches.append(m)
-        else:
-            # Use BFMatcher with Hamming distance for ORB
-            bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
-            matches = bf.match(des1, des2)
-            
-            # Sort matches by distance
-            matches = sorted(matches, key=lambda x: x.distance)
-            
-            # Use only good matches
-            good_matches = matches[:min(100, len(matches))]
-        
-        # Check if we have enough good matches
-        if len(good_matches) < 10:
-            return None
-        
-        # Get matched keypoints
-        self.progress.emit(60, "Computing homography")
-        if using_sift:
-            src_pts = np.float32([kp1[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-            dst_pts = np.float32([kp2[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-        else:
-            src_pts = np.float32([kp1[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-            dst_pts = np.float32([kp2[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-        
-        # Find homography matrix
-        H, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
-        
-        # Scale homography matrix for the full-size image
-        if H is not None:
-            # Adjust for downscaling
-            H[0, 2] *= self.downscale_factor
-            H[1, 2] *= self.downscale_factor
-            
-        return H 
+    def warp_image(self,img,H):
+        # w,h = shape
+        tform = transform.AffineTransform(matrix=H)
+        tf_img = transform.warp(img, tform)
+        return tf_img

--- a/ui/app.py
+++ b/ui/app.py
@@ -226,17 +226,9 @@ class Ui_MainWindow(QMainWindow):
     def _setup_cell_layer_alignment(self):
         """Setup cell layer alignment component and its connections"""
         self.cell_layer_alignment = CellLayerAlignmentUI(
-            self.preprocessing_tab, 
-            self.preprocessing_dockwidget_main_vlayout
+            self.preprocessing_dockwidget_main_vlayout,
+            self.preprocessing_tab
         )
-        
-        # Connect signals
-        self.images_tab.tissue_target_selected.connect(self.cell_layer_alignment.set_target_image)
-        self.images_tab.tissue_unaligned_selected.connect(self.cell_layer_alignment.set_unaligned_image)
-        self.cell_layer_alignment.alignmentCompleteSignal.connect(self.add_item_to_manager)
-        self.cell_layer_alignment.replaceLayerSignal.connect(self.replace_layer_in_canvas)
-        self.cell_layer_alignment.loadOnCanvasSignal.connect(self.load_image_on_canvas)
-        self.cell_layer_alignment.aligner.progress.connect(self.update_progress_bar)
     
     def _setup_view_tab(self):
         """Setup the view tab"""
@@ -411,11 +403,7 @@ class Ui_MainWindow(QMainWindow):
         self.metadata = metadata
         self.metadata_tab.populate_table(self.metadata)
     
-    def add_item_to_manager(self, data, name):
-        """Add item to image manager"""
-        self.images_tab.add_item(data, name)
-    
-    def replace_layer_in_canvas(self, target_image, aligned_image):
+    def replace_layer_in_canvas(self, aligned_image):
         """Replace the second layer in the target image with the aligned image"""
         try:
             # Debug prints
@@ -505,16 +493,16 @@ class Ui_MainWindow(QMainWindow):
         # Update Channel 2
         self.canvas.currentChannelNum = 1  # Index 1 corresponds to Channel 2
         
-        if hasattr(self.canvas, 'update_image'):
-            cmap = getattr(self.canvas.np_channels[channel_name], 'cmap', 'gray')
-            self.canvas.update_image(cmap)
-            self.canvas.loadChannels(self.canvas.np_channels)
+        # if hasattr(self.canvas, 'update_image'):
+        #     cmap = getattr(self.canvas.np_channels[channel_name], 'cmap', 'gray')
+        #     self.canvas.update_image(cmap)
+        #     self.canvas.loadChannels(self.canvas.np_channels)
             
-            # Restore original active channel if different
-            if current_active_channel != 1 and hasattr(self.canvas, 'swap_channel'):
-                self.canvas.swap_channel(current_active_channel)
-        else:
-            self.load_image_on_canvas(aligned_image)
+        #     # Restore original active channel if different
+        #     if current_active_channel != 1 and hasattr(self.canvas, 'swap_channel'):
+        #         self.canvas.swap_channel(current_active_channel)
+        # else:
+        #     self.load_image_on_canvas(aligned_image)
         
         self.update_progress_bar(100, f"Replaced {channel_name} with aligned image")
     

--- a/utils.py
+++ b/utils.py
@@ -17,9 +17,8 @@ def numpy_to_qimage(array:np.ndarray) -> QImage:
         height, width = array.shape
         format = QImage.Format.Format_Grayscale16 if array.dtype == np.uint16 else QImage.Format.Format_Grayscale8
         bytes_per_pixel = 2 if array.dtype == np.uint16 else 1
-        bytes_per_line = width * bytes_per_pixel#uint8
+        bytes_per_line = width * bytes_per_pixel # uint8
         qimage =  QImage(array.data, width, height, bytes_per_line, format)
-
     elif len(array.shape) == 3:
         height, width, channels = array.shape
         if channels == 3:
@@ -104,6 +103,16 @@ def normalize_to_uint8(data: np.ndarray) -> np.ndarray:
     normalized_data = normalized_data.astype(np.uint8)
     return normalized_data
 
+def rgb2gray(rgb):
+    return np.dot(rgb[...,:3], [0.2989, 0.5870, 0.1140])
+
+def convert_image_to_gray(img: np.ndarray) -> np.ndarray:
+    if img.dtype==np.uint16:
+        img = img.astype(np.float32) / 65535.0
+    if is_grayscale(img):
+        return img
+    else:
+        return rgb2gray(img)
 
 def adjustContrast(img, alpha=5, beta=15):  
     
@@ -122,10 +131,76 @@ def scale_adjust(arr:np.ndarray):
         array_uint8 = ((arr / arr.max()) * 255).astype(np.uint8)
         return array_uint8
     else:
-        print("unsupported array type")
-
+        print("unsupported array type: ",arr.dtype)
 
 def auto_contrast(img):
     return adjustContrast(scale_adjust(img))
 
 
+def gaussian_kernel_1d(sigma, radius=None):
+    """Generate 1D Gaussian kernel."""
+    if radius is None:
+        radius = int(np.ceil(3 * sigma))
+    size = 2 * radius + 1
+    x = np.arange(-radius, radius + 1, dtype=np.float32)
+    kernel = np.exp(-(x**2) / (2 * sigma**2))
+    kernel /= kernel.sum()
+    return kernel
+
+
+def gaussian_blur_separable(image, sigma=1.0):
+    """Apply separable Gaussian blur manually using numpy."""
+    kernel = gaussian_kernel_1d(sigma)
+    
+    # Manual separable convolution - more efficient than apply_along_axis
+    # Horizontal pass
+    pad_width = len(kernel) // 2
+    padded = np.pad(image, ((0, 0), (pad_width, pad_width)), mode='reflect')
+    blurred_h = np.zeros_like(image)
+    
+    for i in range(image.shape[0]):
+        blurred_h[i] = np.convolve(padded[i], kernel, mode='valid')
+    
+    # Vertical pass
+    padded = np.pad(blurred_h, ((pad_width, pad_width), (0, 0)), mode='reflect')
+    blurred = np.zeros_like(image)
+    
+    for j in range(image.shape[1]):
+        blurred[:, j] = np.convolve(padded[:, j], kernel, mode='valid')
+    
+    return blurred
+
+def downsample(image, scale=0.5):
+    """Downsample image by given scale factor."""
+    step = int(round(1 / scale))
+    return image[::step, ::step]
+
+
+def build_optical_flow_pyramid_pure_numpy(image, max_level=3, scale=0.5, sigma=1.0, min_size=16):
+    """Version using only numpy with manual separable convolution."""
+    assert image.ndim == 2, "Only grayscale images supported"
+    image = image.astype(np.float32)
+    
+    pyramid = [image]
+    current = image
+    
+    for level in range(max_level):
+        if min(current.shape) < min_size:
+            break
+            
+        blurred = gaussian_blur_separable(current, sigma=sigma)
+        current = downsample(blurred, scale=scale)
+        pyramid.append(current)
+    
+    return pyramid
+
+def adjust_contrast(img, min_percentile=2, max_percentile=98):
+    """Adjust image contrast using percentile-based clipping"""
+    # Calculate percentiles
+    minval = np.percentile(img, min_percentile)
+    maxval = np.percentile(img, max_percentile)
+    
+    # Clip and rescale
+    img_adjusted = np.clip(img, minval, maxval)
+    img_adjusted = ((img_adjusted - minval) / (maxval - minval)) * 255
+    return img_adjusted.astype(np.uint8)


### PR DESCRIPTION
High Level Changes:
- moved most alignment logic out of app.py and into controller.py
- changed .gitignore to ignore local testing files
- added a few functions to utils.py to help alignment but can also be used for pyramid view in the future (hopefully)
- tissue alignment working (but need to test more inputs for robustness) for single channel inputs

Current alignment procedure:
1. Build gaussian pyramid (by default 3 levels, with just numpy) for both moving and reference images when they are selected.
2. After user initiates tissue alignment process, the most course layer of the two pyramids are used for alignment (by default)
3. Both images are contrast adjusted and, if applicable, the bigger image is cropped to be the same size as the lower sized image due to pystackreg requirement
4. Apply pystackreg's register_transform on the two course images to calculate affine homography matrix
5. Apply transformation on matrix based on ratio downsized
6. Apply transformed matrix on unaligned tissue image using transform function from skimage (skimage is in requirements.txt but doesn't seem to be used in the code base; can implement manual transformation function if needed to remove this package) to create aligned tissue image.

TODOs for alignment to be useable:
1. Ability to select a specific channel of input images for alignment (e.g. channel 2 of reference image as target)
2. Ability to save aligned image at full resolution, current it is auto saving the aligned course pyramid combined view as png (micro.png) for debugging.
3. If input is multi channeled, there should be an option to replace a channel with the aligned tissue image.

Other TODOs:
https://docs.google.com/document/d/1ITk2ywbuGE3htQevfus16SrHDIsryHRXYd48kSKd5uQ/edit?usp=sharing
